### PR TITLE
chore: update Node.js version from 20 to 24

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -15,5 +15,5 @@ inputs:
     default: ${{ github.token }}
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/